### PR TITLE
ViewResult offset 

### DIFF
--- a/trombi/client.py
+++ b/trombi/client.py
@@ -535,6 +535,7 @@ class ViewResult(TrombiObject, collections.Sequence):
     def __init__(self, result):
         self._total_rows = result.get('total_rows', len(result['rows']))
         self._rows = result['rows']
+        self.offset = result.get('offset', 0)
 
     def __len__(self):
         return len(self._rows)


### PR DESCRIPTION
I believe the offset should be included within the ViewResult for a couple of reasons:
1. It is data that CouchDB presents (so why not pass it)
2. I am writing a Paginator object that I will submit for review later that requires this variable.

Thanks,

Jarrod Baumann
