### PR TITLE
Prevent accidental attachment removal

### DIFF
--- a/trombi/client.py
+++ b/trombi/client.py
@@ -619,6 +619,11 @@ class Document(collections.MutableMapping, TrombiObject):
             data = json.loads(response.body)
             assert data['id'] == self.id
             self.rev = data['rev']
+            self.attachments[name] = {
+                'content_type': type,
+                'length': len(data),
+                'stub': True,
+            }
             callback(self)
 
         headers = {'Content-Type': type, 'Expect': ''}


### PR DESCRIPTION
Here's a scenario:
1. There's a document mydoc in CouchDB. It has one attachment,
   file1.txt.
2. The user fetches the document:
   
      db.get('mydoc', callback1).
3. The user adds an attachment to the document:
   
      doc.attach('file2.txt', 'Hello, World!', callback2)
4. In callback2, the user modifies the document:
   
      doc['foo'] = 'bar'
      db.set(doc, callback3)`.

Result: attachment file2.txt is removed from CouchDB.

This happens because, in callback2, the document object has the
attachments field, but only the attachment file1.txt is listed. In
db.set(), an _attachments field with only file1.txt is sent, so
CouchDB goes on and removes other attachments, file2.txt in this case.

This patch fixes the issue by adding an appropriate stub to document's
attachments list when doc.attach() finishes.
