### PR TITLE
Adding support for CouchDB user management

### DIFF
--- a/test/test_usermgmt.py
+++ b/test/test_usermgmt.py
@@ -1,0 +1,136 @@
+#
+# Copyright (c) 2011 Daniel Truemper truemped@googlemail.com
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+
+from __future__ import with_statement
+
+from datetime import datetime
+import hashlib
+import sys
+
+from nose.tools import eq_ as eq
+from .couch_util import setup as setup, teardown, with_couchdb
+from .util import with_ioloop, DatetimeEncoder
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+try:
+    # Python 3
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
+except ImportError:
+    # Python 2
+    from urllib2 import urlopen
+    from urllib2 import HTTPError
+
+import trombi
+import trombi.errors
+
+
+@with_ioloop
+@with_couchdb
+def test_add_user(baseurl, ioloop):
+    s = trombi.Server(baseurl, io_loop=ioloop)
+
+    def callback(doc):
+        assert not doc.error
+        ioloop.stop()
+
+    s.add_user('test', 'test', callback)
+    ioloop.start()
+
+
+@with_ioloop
+@with_couchdb
+def test_get_user(baseurl, ioloop):
+    s = trombi.Server(baseurl, io_loop=ioloop)
+
+    def callback(doc):
+        assert not doc.error
+        ioloop.stop()
+
+    s.add_user('get_test', 'test', callback)
+    ioloop.start()
+
+    user = []
+    def callback(doc):
+        assert not doc.error
+        user.append(doc)
+        ioloop.stop()
+
+    s.get_user('get_test', callback)
+    ioloop.start()
+
+    eq(True, isinstance(user[0], trombi.Document))
+
+@with_ioloop
+@with_couchdb
+def test_update_user(baseurl, ioloop):
+    s = trombi.Server(baseurl, io_loop=ioloop)
+    userdoc = []
+
+    def add_callback(doc):
+        assert not doc.error
+        userdoc.append(doc)
+        ioloop.stop()
+
+    s.add_user('updatetest', 'test', add_callback)
+    ioloop.start()
+
+    def update_callback(doc):
+        assert not doc.error
+        userdoc.append(doc)
+        ioloop.stop()
+
+    userdoc[0]['roles'].append('test')
+    s.update_user(userdoc[0], None, update_callback)
+    ioloop.start()
+
+    eq(userdoc[1]['roles'], ['test'])
+
+
+@with_ioloop
+@with_couchdb
+def test_delete_user(baseurl, ioloop):
+    s = trombi.Server(baseurl, io_loop=ioloop)
+    user = []
+
+    def add_callback(doc):
+        assert not doc.error
+        user.append(doc)
+        ioloop.stop()
+
+    s.add_user('deletetest', 'test', add_callback)
+    ioloop.start()
+
+    def delete_callback(db):
+        assert not db.error
+        assert isinstance(db, trombi.Database)
+        ioloop.stop()
+
+    s.delete_user(user[0], delete_callback)
+    ioloop.start()

--- a/test/test_usermgmt.py
+++ b/test/test_usermgmt.py
@@ -107,10 +107,21 @@ def test_update_user(baseurl, ioloop):
         ioloop.stop()
 
     userdoc[0]['roles'].append('test')
-    s.update_user(userdoc[0], None, update_callback)
+    s.update_user(userdoc[0], update_callback)
     ioloop.start()
 
     eq(userdoc[1]['roles'], ['test'])
+
+    def update_passwd_callback(doc):
+        assert not doc.error
+        userdoc.append(doc)
+        ioloop.stop()
+
+    s.update_user_password('updatetest', 'test2', update_passwd_callback)
+    ioloop.start()
+
+    eq(userdoc[1]['salt'], userdoc[2]['salt'])
+    eq(userdoc[1]['password_sha'] != userdoc[2]['password_sha'], True)
 
 
 @with_ioloop

--- a/trombi/client.py
+++ b/trombi/client.py
@@ -259,13 +259,12 @@ class Server(TrombiObject):
             _really_callback,
             )
 
-    def add_user(self, name, password, callback, doc=None):
+    def add_user(self, name, password, callback, doc={}):
         userdb = Database(self, '_users')
 
-        if doc and not isinstance(doc, Document):
+        if not isinstance(doc, Document):
+            user_doc = doc.copy()
             doc = Document(userdb, doc)
-        elif not doc:
-            doc = Document(userdb, {})
 
         doc['type'] = 'user'
         if 'roles' not in doc:


### PR DESCRIPTION
Hi there!

First update from my side about the user management stuff. Will create a new Session API branch based on that tomorrow morning!

Description:
You may call either method on the `trombi.Server` instance:
- add_user(name, password, callback, doc=None)
  Add a user with a name, password and a callback. Optionally
  add the default user doc with the doc arg
- get_user(name, callback)
  Return the user's document
- update_user(user_doc, password, callback)
  Update a user's document. If you want the password not to be
  changed, use `None` as value.
- delete_user(user_doc, callback)
  Simply delete a user document

Best
Daniel
