### PR TITLE
Fixed but with changes() always timing out efter 20 seconds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,5 +7,6 @@ Since open sourcing it following people have helped to develope it
 further (in alphabetical order by last name):
 
 - Jarrod Baumann (https://github.com/jarrodb)
+- David Björkevik (https://github.com/bjorkegeek)
 - Jeremy Kelley (https://github.com/nod)
 - Daniel Truemper (https://github.com/retresco)

--- a/trombi/client.py
+++ b/trombi/client.py
@@ -677,7 +677,7 @@ class Database(TrombiObject):
         if timeout is not None:
             # CouchDB takes timeouts in milliseconds
             couchdb_params['timeout'] = timeout * 1000
-            params['request_timeout'] = timeout + 20
+            params['request_timeout'] = timeout + 1
         url = '_changes?%s' % urlencode(couchdb_params)
         if feed == 'continuous':
             params['streaming_callback'] = _stream

--- a/trombi/client.py
+++ b/trombi/client.py
@@ -673,11 +673,12 @@ class Database(TrombiObject):
 
         couchdb_params = kw
         couchdb_params['feed'] = feed
+        params = dict()
         if timeout is not None:
             # CouchDB takes timeouts in milliseconds
             couchdb_params['timeout'] = timeout * 1000
+            params['request_timeout'] = timeout + 20
         url = '_changes?%s' % urlencode(couchdb_params)
-        params = dict()
         if feed == 'continuous':
             params['streaming_callback'] = _stream
 


### PR DESCRIPTION
Increased tornado http timeout to 20 seconds more than couchdb timeout
when using feed=continuous with changes()
